### PR TITLE
link /tutorials/ from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@ excerpt: Looking for a solid open source alternative to EventBrite or MeetUp? Di
         <a class="btn btn-lg btn-default" href="https://github.com/alfio-event/alf.io" target="_blank"><i class="fa fa-github-square"></i> View on github</a>
         <a class="btn btn-lg btn-default" href="https://demo.alf.io/admin/" title="try alf.io!" target="_blank"><i class="fa fa-play-circle"></i> Try it!</a>
         <a class="btn btn-lg btn-success" href="https://github.com/alfio-event/alf.io/releases/latest" target="_blank"><i class="fa fa-download"></i> Download</a>
+        <a class="btn btn-lg btn-default" href="/tutorials/import-attendees/"><i class="fa fa-book"></i> Tutorials</a>
         <div class="text-center" style="margin-top:15px">
           <a href="https://twitter.com/alfio_event" class="twitter-follow-button" data-show-count="false">Follow @alfio_event</a>
           <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>


### PR DESCRIPTION
because otherwise they are *REALLY* hidden and hard to find

There is no index page, so just link to first useful tutorial - people will see the menu on top and figure it out from there